### PR TITLE
Fix RSS not available, and other "broken" links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ description: > # this means to ignore newlines until "baseurl:"
   
   
 baseurl: "/newsletter" # the subpath of your site, e.g. /blog
-url: "https://github.com/ZeroPhone" # the base hostname & protocol for your site
+url: "https://zerophone.github.io" # the base hostname & protocol for your site
 
 #sidebar
 default-image: ZeroPhone1.jpg # If there is no featured image in a post then this image will be showed. Also on all pages this image will be showed. Use a 500x250 image.


### PR DESCRIPTION
Jekyll config had wrong URL, pointing to the github project, and not the built website.